### PR TITLE
Allow precompile tasks to run on their own

### DIFF
--- a/src/main/groovy/org/gradle/api/plugins/gaelyk/GaelykPlugin.groovy
+++ b/src/main/groovy/org/gradle/api/plugins/gaelyk/GaelykPlugin.groovy
@@ -32,6 +32,8 @@ import org.gradle.api.plugins.gaelyk.tasks.*
 
 import static eu.appsatori.gradle.fatjar.FatJarPlugin.*
 import static org.gradle.api.plugins.gae.GaePlugin.GAE_RUN
+import static org.gradle.api.plugins.JavaPlugin.CLASSES_TASK_NAME
+import static org.gradle.api.plugins.WarPlugin.WAR_TASK_NAME
 
 /**
  * <p>A {@link org.gradle.api.Plugin} that provides tasks for managing Gaelyk projects.</p>
@@ -122,8 +124,9 @@ class GaelykPlugin implements Plugin<Project> {
         gaelykPrecompileGroovletTask.description = "Precompiles Groovlets."
         gaelykPrecompileGroovletTask.group = GAELYK_GROUP
         gaelykPrecompileGroovletTask.onlyIf { !gaeRunIsInGraph(project) }
-        
-        project.tasks.classes.dependsOn(gaelykPrecompileGroovletTask)
+
+        gaelykPrecompileGroovletTask.dependsOn(project.tasks.findByName(CLASSES_TASK_NAME))
+        project.tasks.findByName(WAR_TASK_NAME).dependsOn(gaelykPrecompileGroovletTask)
     }
     
     private void configureGaelykPrecompileTemplate(final Project project) {
@@ -138,8 +141,9 @@ class GaelykPlugin implements Plugin<Project> {
         gaelykPrecompileTemplateTask.description = "Precompiles Groovlets."
         gaelykPrecompileTemplateTask.group = GAELYK_GROUP
         gaelykPrecompileTemplateTask.onlyIf { !gaeRunIsInGraph(project) }
-        
-        project.tasks.classes.dependsOn(gaelykPrecompileTemplateTask)
+
+        gaelykPrecompileTemplateTask.dependsOn(project.tasks.findByName(CLASSES_TASK_NAME))
+        project.tasks.findByName(WAR_TASK_NAME).dependsOn(gaelykPrecompileTemplateTask)
     }
 
     private void configureGaelykCreateControllerTask(final Project project) {

--- a/src/test/groovy/org/gradle/api/plugins/gaelyk/integration/PrecompileTasksIntegrationSpec.groovy
+++ b/src/test/groovy/org/gradle/api/plugins/gaelyk/integration/PrecompileTasksIntegrationSpec.groovy
@@ -1,7 +1,10 @@
 package org.gradle.api.plugins.gaelyk.integration
 
-import static org.gradle.api.plugins.gaelyk.GaelykPlugin.*
-import static org.gradle.api.plugins.gae.GaePlugin.*
+import org.gradle.BuildResult
+import static org.gradle.api.plugins.gae.GaePlugin.getGAE_RUN
+import static org.gradle.api.plugins.gaelyk.GaelykPlugin.getGAELYK_PRECOMPILE_GROOVLET
+import static org.gradle.api.plugins.gaelyk.GaelykPlugin.getGAELYK_PRECOMPILE_TEMPLATE
+import spock.lang.Unroll
 
 class PrecompileTasksIntegrationSpec extends IntegrationSpec {
     def 'precompile tasks should be skipped when gaeRun is in task graph'() {
@@ -13,5 +16,26 @@ class PrecompileTasksIntegrationSpec extends IntegrationSpec {
 
         then:
         tasks(GAELYK_PRECOMPILE_GROOVLET, GAELYK_PRECOMPILE_TEMPLATE).every { it.state.skipped }
+    }
+
+    @Unroll
+    def '#task tasks should not blow up if run on its own and when precompiled contents depend on compiled classes'() {
+        given:
+        file('src/main/groovy/test/A.groovy') << '''
+            package test
+            class A {}
+        '''
+        file("$DEFAULT_WEB_APP_PATH/WEB-INF/$path") << contents
+
+        when:
+        BuildResult result = launcher(task).run()
+
+        then:
+        !result.failure
+
+        where:
+        task                       | path                     | contents
+        GAELYK_PRECOMPILE_GROOVLET | 'groovy/groovlet.groovy' | 'new test.A()'
+        GAELYK_PRECOMPILE_TEMPLATE | 'pages/template.gtpl'    | '<% new test.A() %>'
     }
 }


### PR DESCRIPTION
Modified precompile tasks' dependencies so that they can be run on their own

Fix for https://github.com/bmuschko/gradle-gaelyk-plugin/issues/25
